### PR TITLE
Add ability to configure codedeploy agent to be enabled on boot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,6 @@ codedeploy_install_script_dest: "{{ default_codedeploy_install_script_dest }}"
 
 # CodeDeploy agent service state after instalation
 codedeploy_service_state: started
+
+# Codedeploy agent service enabled after boot or not
+codedeploy_service_enabled: yes

--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -26,4 +26,4 @@
   service:
     name: codedeploy-agent
     state: "{{ codedeploy_service_state }}"
-    enabled: yes
+    enabled: "{{ codedeploy_service_enabled }}"

--- a/tasks/setup-Win32NT.yml
+++ b/tasks/setup-Win32NT.yml
@@ -14,5 +14,5 @@
 - name: Windows | CodeDeploy agent service
   win_service:
     name: codedeployagent
-    start_mode: auto
+    start_mode: "{{ codedeploy_service_enabled | ternary('auto', 'disabled') }}"
     state: "{{ codedeploy_service_state }}"


### PR DESCRIPTION
Add variable to configure service whether it's enabled on boot or not.
Yes, to enable / auto run the service on boot
No, to disable service, it will not start on boot.